### PR TITLE
Add ASP.NET Core + React form/template example

### DIFF
--- a/MyAspNetReactApp/ClientApp/package.json
+++ b/MyAspNetReactApp/ClientApp/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "clientapp",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-hook-form": "^7.45.0",
+    "html2pdf.js": "^0.10.1",
+    "pizzip": "^3.1.5",
+    "docxtemplater": "^3.31.0",
+    "file-saver": "^2.0.5"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development --open",
+    "build": "webpack --mode production"
+  },
+  "devDependencies": {
+    "webpack": "^5.86.0",
+    "webpack-cli": "^5.1.1",
+    "webpack-dev-server": "^4.15.0",
+    "@babel/core": "^7.22.15",
+    "@babel/preset-env": "^7.22.15",
+    "@babel/preset-react": "^7.22.5",
+    "babel-loader": "^9.1.3"
+  }
+}

--- a/MyAspNetReactApp/ClientApp/public/index.html
+++ b/MyAspNetReactApp/ClientApp/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>React Template Example</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="../dist/bundle.js"></script>
+</body>
+</html>

--- a/MyAspNetReactApp/ClientApp/src/App.jsx
+++ b/MyAspNetReactApp/ClientApp/src/App.jsx
@@ -1,0 +1,47 @@
+import React, { useRef, useState } from 'react';
+import FormLeft from './components/FormLeft';
+import TemplateRight from './components/TemplateRight';
+import html2pdf from 'html2pdf.js';
+import { saveAs } from 'file-saver';
+import PizZip from 'pizzip';
+import Docxtemplater from 'docxtemplater';
+
+export default function App() {
+  const [formData, setFormData] = useState({
+    name: '',
+    position: '',
+    showDetails: true
+  });
+  const templateRef = useRef();
+
+  const exportPdf = () => {
+    const opt = { margin: 1, filename: 'template.pdf' };
+    html2pdf().from(templateRef.current).set(opt).save();
+  };
+
+  const exportDocx = () => {
+    const template = `\
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p><w:r><w:t>Name: ${formData.name}</w:t></w:r></w:p>
+          <w:p><w:r><w:t>Position: ${formData.position}</w:t></w:r></w:p>
+        </w:body>
+      </w:document>`;
+    const zip = new PizZip();
+    zip.file('word/document.xml', template);
+    const doc = new Docxtemplater(zip, { paragraphLoop: true, linebreaks: true });
+    const blob = doc.getZip().generate({ type: 'blob', mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' });
+    saveAs(blob, 'template.docx');
+  };
+
+  return (
+    <div className="app">
+      <FormLeft onUpdate={setFormData} />
+      <div className="actions">
+        <button onClick={exportPdf}>Export PDF</button>
+        <button onClick={exportDocx}>Export DOCX</button>
+      </div>
+      <TemplateRight data={formData} ref={templateRef} />
+    </div>
+  );
+}

--- a/MyAspNetReactApp/ClientApp/src/components/FormLeft.jsx
+++ b/MyAspNetReactApp/ClientApp/src/components/FormLeft.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+
+export default function FormLeft({ onUpdate }) {
+  const { register, handleSubmit } = useForm({
+    defaultValues: { name: '', position: '', showDetails: true }
+  });
+
+  const onSubmit = (data) => {
+    onUpdate(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="form-left">
+      <div>
+        <label>Name</label>
+        <input {...register('name')} />
+      </div>
+      <div>
+        <label>Position</label>
+        <input {...register('position')} />
+      </div>
+      <div>
+        <label>
+          <input type="checkbox" {...register('showDetails')} /> Show details
+        </label>
+      </div>
+      <button type="submit">Apply</button>
+    </form>
+  );
+}

--- a/MyAspNetReactApp/ClientApp/src/components/TemplateRight.jsx
+++ b/MyAspNetReactApp/ClientApp/src/components/TemplateRight.jsx
@@ -1,0 +1,18 @@
+import React, { forwardRef } from 'react';
+
+const TemplateRight = forwardRef(({ data }, ref) => {
+  return (
+    <div className="template-right" ref={ref}>
+      <h2>Employee Card</h2>
+      <p><strong>Name:</strong> {data.name}</p>
+      <p><strong>Position:</strong> {data.position}</p>
+      {data.showDetails && (
+        <div className="details">
+          <p>Here could be more detailed information...</p>
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default TemplateRight;

--- a/MyAspNetReactApp/ClientApp/src/index.css
+++ b/MyAspNetReactApp/ClientApp/src/index.css
@@ -1,0 +1,13 @@
+.app {
+  display: flex;
+}
+.form-left {
+  margin-right: 20px;
+}
+.template-right {
+  border: 1px solid #ccc;
+  padding: 10px;
+}
+.actions {
+  margin: 10px 0;
+}

--- a/MyAspNetReactApp/ClientApp/src/index.js
+++ b/MyAspNetReactApp/ClientApp/src/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/MyAspNetReactApp/ClientApp/webpack.config.js
+++ b/MyAspNetReactApp/ClientApp/webpack.config.js
@@ -1,0 +1,35 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  devServer: {
+    static: './dist',
+    port: 3000,
+    hot: true
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env', '@babel/preset-react']
+          }
+        }
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader']
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['.js', '.jsx']
+  }
+};

--- a/MyAspNetReactApp/Controllers/WeatherForecastController.cs
+++ b/MyAspNetReactApp/Controllers/WeatherForecastController.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
+{
+    [HttpGet]
+    public string Get() => "API works";
+}

--- a/MyAspNetReactApp/Program.cs
+++ b/MyAspNetReactApp/Program.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.UseDefaultFiles();
+app.UseStaticFiles();
+app.MapControllers();
+
+app.Run();

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-README
+# ASP.NET + React Example
+
+This repository shows a minimal example of an ASP.NET Core project with a React client application.
+The client renders a form on the left and a document template on the right. Values typed in the form
+control the template. Buttons allow exporting the template area to PDF and DOCX on the client side.
+
+```
+MyAspNetReactApp/
+  ClientApp/       - React frontend
+    src/
+      components/
+        FormLeft.jsx
+        TemplateRight.jsx
+      App.jsx
+      index.js
+      index.css
+    package.json
+    webpack.config.js
+    public/index.html
+  Controllers/     - sample ASP.NET Core controllers
+  Program.cs       - minimal ASP.NET Core host
+```
+
+The React application uses **react-hook-form** to manage the form, **html2pdf.js** to export to PDF
+and **docxtemplater** to build a DOCX file. See `ClientApp/src/App.jsx` for how the form data affects
+the template and how export functions are implemented.


### PR DESCRIPTION
## Summary
- add sample ASP.NET Core host and controller
- add React client app showing form-controlled template
- document PDF and DOCX export example

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68420dd0b7e883298d9eed5b7553ad55