### PR TITLE
Add Fluid PDF console app

### DIFF
--- a/LiquidPdfExporter/LiquidPdfExporter.csproj
+++ b/LiquidPdfExporter/LiquidPdfExporter.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Fluid" Version="2.3.1" />
+    <PackageReference Include="HtmlRendererCore.PdfSharpCore" Version="1.5.0" />
+    <PackageReference Include="PdfSharpCore" Version="1.3.36" />
+  </ItemGroup>
+
+</Project>

--- a/LiquidPdfExporter/Program.cs
+++ b/LiquidPdfExporter/Program.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Fluid;
+using PdfSharpCore.Pdf;
+using TheArtOfDev.HtmlRenderer.PdfSharp;
+
+namespace LiquidPdfExporter
+{
+    class Program
+    {
+        static object ConvertJsonElement(JsonElement element)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    var dict = new Dictionary<string, object?>();
+                    foreach (var property in element.EnumerateObject())
+                    {
+                        dict[property.Name] = ConvertJsonElement(property.Value);
+                    }
+                    return dict;
+                case JsonValueKind.Array:
+                    var list = new List<object?>();
+                    foreach (var item in element.EnumerateArray())
+                    {
+                        list.Add(ConvertJsonElement(item));
+                    }
+                    return list;
+                case JsonValueKind.String:
+                    return element.GetString();
+                case JsonValueKind.Number:
+                    if (element.TryGetInt64(out var l)) return l;
+                    if (element.TryGetDouble(out var d)) return d;
+                    return null;
+                case JsonValueKind.True:
+                    return true;
+                case JsonValueKind.False:
+                    return false;
+                default:
+                    return null;
+            }
+        }
+
+        static void Main(string[] args)
+        {
+            var templateFile = args.Length > 0 ? args[0] : "Template.liquid";
+            var jsonFile = args.Length > 1 ? args[1] : "data.json";
+            var outputFile = args.Length > 2 ? args[2] : "output.pdf";
+
+            var templateText = File.ReadAllText(templateFile);
+            var jsonText = File.ReadAllText(jsonFile);
+
+            using var document = JsonDocument.Parse(jsonText);
+            var model = (Dictionary<string, object?>)ConvertJsonElement(document.RootElement);
+
+            var parser = new FluidParser();
+            if (!parser.TryParse(templateText, out var template, out var error))
+            {
+                Console.WriteLine($"Template error: {error}");
+                return;
+            }
+
+            var options = new TemplateOptions();
+            options.MemberAccessStrategy.RegisterDictionaryAccess();
+            var context = new TemplateContext(model, options);
+
+            var html = template.Render(context);
+
+            PdfDocument pdf = PdfGenerator.GeneratePdf(html, PdfSharpCore.PageSize.A4);
+            pdf.Save(outputFile);
+
+            Console.WriteLine($"PDF generated: {outputFile}");
+        }
+    }
+}

--- a/LiquidPdfExporter/Template.liquid
+++ b/LiquidPdfExporter/Template.liquid
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Liquid PDF Example</title>
+</head>
+<body>
+    <h1>Hello {{ user.name }}</h1>
+    <p>Email: {{ user.email }}</p>
+    <ul>
+    {% for item in user.items %}
+        <li>{{ item }}</li>
+    {% endfor %}
+    </ul>
+</body>
+</html>

--- a/LiquidPdfExporter/data.json
+++ b/LiquidPdfExporter/data.json
@@ -1,0 +1,7 @@
+{
+  "user": {
+    "name": "John Doe",
+    "email": "john@example.com",
+    "items": ["Item 1", "Item 2", "Item 3"]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-README
+# Liquid PDF Exporter
+
+This repository contains a simple .NET 8 console application that fills a Liquid template with data from a JSON file and exports the result as a PDF document.
+
+## Building
+
+```bash
+# Ensure .NET 8 SDK is installed
+cd LiquidPdfExporter
+ dotnet restore
+ dotnet build -c Release
+```
+
+## Running
+
+```bash
+# from the project directory
+ dotnet run -- Template.liquid data.json output.pdf
+```
+
+This command generates `output.pdf` by applying `data.json` to `Template.liquid`.


### PR DESCRIPTION
## Summary
- add a .NET 8 console project that renders a Liquid template using Fluid and converts it to PDF
- provide an example template and JSON data
- document build and run steps in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dbd6be888329851f18feb1dd0f52